### PR TITLE
Fix #2: Qualify internal migrations table references

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,13 @@ pgroll [global options] <command>
 
 ### Global options
 
-| Option                      | Description                                                     |
-| --------------------------- | --------------------------------------------------------------- |
-| `-d, --migrationDir <path>` | Directory holding the migration files (default `./migrations`). |
-| `-u, --url <url>`           | PostgreSQL connection URL (overrides `PG*` env vars).           |
-| `-V, --version`             | Print the `pgroll` version.                                     |
-| `-h, --help`                | Show help.                                                      |
+| Option                      | Description                                                      |
+| --------------------------- | ---------------------------------------------------------------  |
+| `-d, --migrationDir <path>` | Directory holding the migration files (default: `./migrations`). |
+| `-u, --url <url>`           | PostgreSQL connection URL (overrides `PG*` env vars).            |
+| `-s, --schema <schema>`     | Schema for pgroll's internal migrations table (default: public). |
+| `-V, --version`             | Print the `pgroll` version.                                      |
+| `-h, --help`                | Show help.                                                       |
 
 ### Commands
 

--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ pgroll [global options] <command>
 
 ### Global options
 
-| Option                      | Description                                                      |
-| --------------------------- | ---------------------------------------------------------------  |
-| `-d, --migrationDir <path>` | Directory holding the migration files (default: `./migrations`). |
-| `-u, --url <url>`           | PostgreSQL connection URL (overrides `PG*` env vars).            |
-| `-s, --schema <schema>`     | Schema for pgroll's internal migrations table (default: public). |
-| `-V, --version`             | Print the `pgroll` version.                                      |
-| `-h, --help`                | Show help.                                                       |
+| Option                      | Description                                                        |
+| --------------------------- | ------------------------------------------------------------------ |
+| `-d, --migrationDir <path>` | Directory holding the migration files (default: `./migrations`).   |
+| `-u, --url <url>`           | PostgreSQL connection URL (overrides `PG*` env vars).              |
+| `-s, --schema <schema>`     | Schema for pgroll's internal migrations table (default: `public`). |
+| `-V, --version`             | Print the `pgroll` version.                                        |
+| `-h, --help`                | Show help.                                                         |
 
 ### Commands
 
@@ -160,12 +160,13 @@ await migrator.go(0, { eventHandler: info => console.log(info) });
 await sql.end();
 ```
 
-### `new Migrator(dbClient, migrationsDir?)`
+### `new Migrator(dbClient, migrationsDir?, schema?)`
 
-| Parameter       | Type                | Description                                                   |
-| --------------- | ------------------- | ------------------------------------------------------------- |
-| `dbClient`      | `Sql` (PostgresJS)  | A `postgres` client instance.                                 |
-| `migrationsDir` | `string` (optional) | Directory of migration files. Defaults to `<cwd>/migrations`. |
+| Parameter       | Type                | Description                                                          |
+| --------------- | ------------------- | -------------------------------------------------------------------- |
+| `dbClient`      | `Sql` (PostgresJS)  | A `postgres` client instance.                                        |
+| `migrationsDir` | `string` (optional) | Directory of migration files. Defaults to `<cwd>/migrations`.        |
+| `schema`        | `string` (optional) | Schema for pgroll's internal migrations table. Defaults to `public`. |
 
 ### Methods
 
@@ -181,10 +182,12 @@ human-readable message as each migration is applied.
 
 ## How it works
 
-On the first run, `pgroll` creates a bookkeeping table:
+On the first run, `pgroll` creates a bookkeeping table in the configured schema (default
+`public`, override with `-s, --schema`). All references to it are schema-qualified, so it is
+unaffected by any `search_path` a migration sets:
 
 ```sql
-CREATE TABLE IF NOT EXISTS migrations (
+CREATE TABLE IF NOT EXISTS <schema>.migrations (
   name       varchar(500) PRIMARY KEY,
   version    smallint NOT NULL,
   applied_at timestamp DEFAULT CURRENT_TIMESTAMP

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,4 +9,6 @@ services:
       PGDATA: /data/postgres
     volumes:
       - ./data/db:/data/postgres
-    network_mode: host
+    ports:
+      - 5432:5432
+    # network_mode: host

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,4 +11,3 @@ services:
       - ./data/db:/data/postgres
     ports:
       - 5432:5432
-    # network_mode: host

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "license": "ISC",
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@types/node": "^26.0.0",
+    "@types/node": "^26.0.1",
     "@vitest/coverage-v8": "^4.1.9",
     "@vitest/eslint-plugin": "^1.6.20",
     "eslint": "^10.5.0",
@@ -59,7 +59,7 @@
     "eslint-plugin-import-x": "^4.17.0",
     "eslint-plugin-promise": "^7.3.0",
     "eslint-plugin-sonarjs": "^4.1.0",
-    "eslint-plugin-unicorn": "^68.0.0",
+    "eslint-plugin-unicorn": "^69.0.0",
     "globals": "^17.7.0",
     "prettier": "^3.8.4",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.5.0)
       '@types/node':
-        specifier: ^26.0.0
-        version: 26.0.0
+        specifier: ^26.0.1
+        version: 26.0.1
       '@vitest/coverage-v8':
         specifier: ^4.1.9
         version: 4.1.9(vitest@4.1.9)
@@ -46,8 +46,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(eslint@10.5.0)
       eslint-plugin-unicorn:
-        specifier: ^68.0.0
-        version: 68.0.0(eslint@10.5.0)
+        specifier: ^69.0.0
+        version: 69.0.0(eslint@10.5.0)
       globals:
         specifier: ^17.7.0
         version: 17.7.0
@@ -62,7 +62,7 @@ importers:
         version: 8.62.0(eslint@10.5.0)(typescript@6.0.3)
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(vite@8.0.14(@types/node@26.0.0)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.9(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(vite@8.0.14(@types/node@26.0.1)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.9.0))
 
 packages:
 
@@ -449,8 +449,8 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
-  '@types/node@26.0.0':
-    resolution: {integrity: sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==}
+  '@types/node@26.0.1':
+    resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
 
   '@typescript-eslint/eslint-plugin@8.62.0':
     resolution: {integrity: sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==}
@@ -734,8 +734,8 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.10.38:
-    resolution: {integrity: sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==}
+  baseline-browser-mapping@2.10.40:
+    resolution: {integrity: sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1003,8 +1003,8 @@ packages:
     peerDependencies:
       eslint: ^8.0.0 || ^9.0.0 || ^10.0.0
 
-  eslint-plugin-unicorn@68.0.0:
-    resolution: {integrity: sha512-mHYWvX948Q4H3bGc39bsNMxD/leOuNI+Iws9NVsoSz5VA7EGP86wnz7mZ/SPSvRhefT8L4hd8DHfDuGC+lIoCQ==}
+  eslint-plugin-unicorn@69.0.0:
+    resolution: {integrity: sha512-ZN/KtHr9hQ6AOByANSNJpsDbo/+Nn+EyQ6blK4w+dcmS/xpYkqLLfrUc+NA/wOK6vF5uEUvhn8my5B/3sruB9g==}
     engines: {node: '>=22'}
     peerDependencies:
       eslint: '>=10.4'
@@ -1054,8 +1054,8 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  expect-type@1.3.0:
-    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
@@ -1480,8 +1480,8 @@ packages:
     resolution: {integrity: sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==}
     engines: {node: '>= 0.4'}
 
-  node-releases@2.0.49:
-    resolution: {integrity: sha512-f06bl1D+8ZDkn2oOQQKAh5/otFWqVnM1Q5oerA8Pex7UfT66Tx4IPHIqVVFKqFT3FUtaDstdgkM7yT7JWhqxfw==}
+  node-releases@2.0.50:
+    resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
     engines: {node: '>=18'}
 
   object-inspect@1.13.4:
@@ -2187,7 +2187,7 @@ snapshots:
   '@types/json5@0.0.29':
     optional: true
 
-  '@types/node@26.0.0':
+  '@types/node@26.0.1':
     dependencies:
       undici-types: 8.3.0
 
@@ -2364,7 +2364,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(vite@8.0.14(@types/node@26.0.0)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(vite@8.0.14(@types/node@26.0.1)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.20(@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3)(vitest@4.1.9)':
     dependencies:
@@ -2374,7 +2374,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3)
       typescript: 6.0.3
-      vitest: 4.1.9(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(vite@8.0.14(@types/node@26.0.0)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(vite@8.0.14(@types/node@26.0.1)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -2387,13 +2387,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@8.0.14(@types/node@26.0.0)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.9(vite@8.0.14(@types/node@26.0.1)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.14(@types/node@26.0.0)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 8.0.14(@types/node@26.0.1)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.9':
     dependencies:
@@ -2509,7 +2509,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.10.38: {}
+  baseline-browser-mapping@2.10.40: {}
 
   brace-expansion@1.1.15:
     dependencies:
@@ -2523,10 +2523,10 @@ snapshots:
 
   browserslist@4.28.4:
     dependencies:
-      baseline-browser-mapping: 2.10.38
+      baseline-browser-mapping: 2.10.40
       caniuse-lite: 1.0.30001799
       electron-to-chromium: 1.5.378
-      node-releases: 2.0.49
+      node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
   builtin-modules@3.3.0: {}
@@ -2899,7 +2899,7 @@ snapshots:
       typescript: 6.0.3
       yaml: 2.9.0
 
-  eslint-plugin-unicorn@68.0.0(eslint@10.5.0):
+  eslint-plugin-unicorn@69.0.0(eslint@10.5.0):
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
@@ -2987,7 +2987,7 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  expect-type@1.3.0: {}
+  expect-type@1.4.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -3425,7 +3425,7 @@ snapshots:
       semver: 6.3.1
     optional: true
 
-  node-releases@2.0.49: {}
+  node-releases@2.0.50: {}
 
   object-inspect@1.13.4:
     optional: true
@@ -3885,7 +3885,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite@8.0.14(@types/node@26.0.0)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.9.0):
+  vite@8.0.14(@types/node@26.0.1)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -3893,23 +3893,23 @@ snapshots:
       rolldown: 1.0.2
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
       esbuild: 0.28.0
       fsevents: 2.3.3
       tsx: 4.22.3
       yaml: 2.9.0
 
-  vitest@4.1.9(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(vite@8.0.14(@types/node@26.0.0)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.9.0)):
+  vitest@4.1.9(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(vite@8.0.14(@types/node@26.0.1)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.0.14(@types/node@26.0.0)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.9(vite@8.0.14(@types/node@26.0.1)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
       '@vitest/spy': 4.1.9
       '@vitest/utils': 4.1.9
       es-module-lexer: 2.1.0
-      expect-type: 1.3.0
+      expect-type: 1.4.0
       magic-string: 0.30.21
       obug: 2.1.3
       pathe: 2.0.3
@@ -3919,10 +3919,10 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.14(@types/node@26.0.0)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 8.0.14(@types/node@26.0.1)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
       '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
     transitivePeerDependencies:
       - msw

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,16 +16,17 @@ let migrator: IMigrator;
 program
   .version('0.0.9')
   .description('Database migration tool')
-  .option('-d, --migrationDir <filepath>', 'Specify migration directory(Default: ./migrations)')
+  .option('-d, --migrationDir <filepath>', 'Specify migration directory (Default: ./migrations)')
   .option('-u, --url <url>', 'PostgreSQL connection URL (overrides PG* env vars)')
+  .option('-s, --schema <schema>', 'Specify schema (Default: public)')
   .hook('preAction', cmd => {
-    const opts = cmd.opts<{ migrationDir?: string; url?: string }>();
+    const opts = cmd.opts<{ migrationDir?: string; url?: string; schema?: string }>();
     const pgOptions = {
       onnotice: () => {
         // do nothing
       }
     };
-    migrator = new Migrator(opts.url ? postgres(opts.url, pgOptions) : postgres(pgOptions), opts.migrationDir);
+    migrator = new Migrator(opts.url ? postgres(opts.url, pgOptions) : postgres(pgOptions), opts.migrationDir, opts.schema);
   });
 
 program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,7 +26,11 @@ program
         // do nothing
       }
     };
-    migrator = new Migrator(opts.url ? postgres(opts.url, pgOptions) : postgres(pgOptions), opts.migrationDir, opts.schema);
+    migrator = new Migrator(
+      opts.url ? postgres(opts.url, pgOptions) : postgres(pgOptions),
+      opts.migrationDir,
+      opts.schema
+    );
   });
 
 program

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ export class Migrator implements IMigrator {
       const currentVersion = await this.getCurrentVersionWithTx(tx);
       if (currentVersion === version) {
         opts?.eventHandler(`Already at version ${version}`);
+        await this.commit(tx);
         return;
       }
       const direction: Direction = version > currentVersion ? 'up' : 'down';

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,14 +22,15 @@ export class Migrator implements IMigrator {
   readonly migrationsDir: string;
   readonly schema: string;
 
-  constructor(dbClient: Sql, migrationsDir = '', schema = '') {
+  constructor(dbClient: Sql, migrationsDir = '', schema = 'public') {
     this.dbClient = dbClient;
     this.migrationsDir = migrationsDir || `${process.cwd()}/migrations`;
-    this.schema = schema ?? "public";
+    this.schema = schema;
   }
 
   async ensureMigrationTable(tx: ReservedSql): Promise<void> {
-    await tx`CREATE TABLE IF NOT EXISTS ${this.schema}.migrations(
+    await tx`CREATE SCHEMA IF NOT EXISTS ${tx(this.schema)}`;
+    await tx`CREATE TABLE IF NOT EXISTS ${tx(this.schema)}.migrations(
                         name varchar(500) PRIMARY KEY,
                         version smallint NOT NULL,
                         applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP);`;
@@ -60,8 +61,8 @@ export class Migrator implements IMigrator {
         const fileVersion = Math.min(fileNames.length, version);
         for (let i = currentVersion; i < fileVersion; i++) {
           const file = fileNames[i] ?? '';
-          await  tx.file(path.join(this.migrationsDir, file)).execute();
-          await  tx`INSERT INTO ${this.schema}.migrations(name, version) VALUES (${file}, ${i} + 1)`;
+          await tx.file(path.join(this.migrationsDir, file)).execute();
+          await tx`INSERT INTO ${tx(this.schema)}.migrations(name, version) VALUES (${file}, ${i} + 1)`;
           opts?.eventHandler(`Successfully migrated: ${file}`);
         }
         if (version > fileNames.length) {
@@ -75,7 +76,7 @@ export class Migrator implements IMigrator {
         for (let i = start; i < end; i++) {
           const file = fileNames[i] ?? '';
           await tx.file(path.join(this.migrationsDir, file)).execute();
-          await tx`DELETE FROM ${this.schema}.migrations WHERE version = ${fileNames.length - i}`;
+          await tx`DELETE FROM ${tx(this.schema)}.migrations WHERE version = ${fileNames.length - i}`;
           opts?.eventHandler(`Successfully migrated: ${file}`);
         }
       }
@@ -101,8 +102,8 @@ export class Migrator implements IMigrator {
         for (const fileName of fileNames) {
           const id = fileNames.indexOf(fileName);
           if (id >= currentVersion) {
-            await  tx.file(path.join(this.migrationsDir, fileName)).execute();
-            await  tx`INSERT INTO ${this.schema}.migrations(name, version) VALUES (${fileName}, ${id} + 1)`;
+            await tx.file(path.join(this.migrationsDir, fileName)).execute();
+            await tx`INSERT INTO ${tx(this.schema)}.migrations(name, version) VALUES (${fileName}, ${id} + 1)`;
             opts?.eventHandler(`Successfully migrated: ${fileName}`);
           }
         }
@@ -111,8 +112,8 @@ export class Migrator implements IMigrator {
         const start = fileNames.length - currentVersion;
         for (let i = start; i < fileNames.length; i++) {
           const file = fileNames[i] ?? '';
-          await  tx.file(path.join(this.migrationsDir, file)).execute();
-          await  tx`DELETE FROM ${this.schema}.migrations WHERE version = ${fileNames.length - i}`;
+          await tx.file(path.join(this.migrationsDir, file)).execute();
+          await tx`DELETE FROM ${tx(this.schema)}.migrations WHERE version = ${fileNames.length - i}`;
           opts?.eventHandler(`Successfully migrated: ${file}`);
         }
       }
@@ -127,12 +128,13 @@ export class Migrator implements IMigrator {
   }
 
   async getCurrentVersion(): Promise<number> {
-    const result = await this.dbClient`SELECT version FROM ${this.schema}.migrations ORDER BY version DESC LIMIT 1`;
+    const result = await this
+      .dbClient`SELECT version FROM ${this.dbClient(this.schema)}.migrations ORDER BY version DESC LIMIT 1`;
     return result.length > 0 ? (result[0]?.['version'] as number) : 0;
   }
 
   async getCurrentVersionWithTx(tx: ReservedSql): Promise<number> {
-    const result = await tx`SELECT version FROM ${this.schema}.migrations ORDER BY version DESC LIMIT 1`;
+    const result = await tx`SELECT version FROM ${tx(this.schema)}.migrations ORDER BY version DESC LIMIT 1`;
     return result.length > 0 ? (result[0]?.['version'] as number) : 0;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ interface Option {
 
 export interface IMigrator {
   migrationsDir: string;
+  schema: string;
   up: (opts?: Option) => Promise<void>;
   down: (opts?: Option) => Promise<void>;
   go: (version: number, opts?: Option) => Promise<void>;
@@ -19,14 +20,16 @@ export interface IMigrator {
 export class Migrator implements IMigrator {
   private readonly dbClient: Sql;
   readonly migrationsDir: string;
+  readonly schema: string;
 
-  constructor(dbClient: Sql, migrationsDir = '') {
+  constructor(dbClient: Sql, migrationsDir = '', schema = '') {
     this.dbClient = dbClient;
     this.migrationsDir = migrationsDir || `${process.cwd()}/migrations`;
+    this.schema = schema ?? "public";
   }
 
   async ensureMigrationTable(tx: ReservedSql): Promise<void> {
-    await tx`CREATE TABLE IF NOT EXISTS migrations(
+    await tx`CREATE TABLE IF NOT EXISTS ${this.schema}.migrations(
                         name varchar(500) PRIMARY KEY,
                         version smallint NOT NULL,
                         applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP);`;
@@ -57,10 +60,8 @@ export class Migrator implements IMigrator {
         const fileVersion = Math.min(fileNames.length, version);
         for (let i = currentVersion; i < fileVersion; i++) {
           const file = fileNames[i] ?? '';
-          await Promise.all([
-            tx.file(path.join(this.migrationsDir, file)).execute(),
-            tx`INSERT INTO migrations(name, version) VALUES (${file}, ${i} + 1)`
-          ]);
+          await  tx.file(path.join(this.migrationsDir, file)).execute();
+          await  tx`INSERT INTO ${this.schema}.migrations(name, version) VALUES (${file}, ${i} + 1)`;
           opts?.eventHandler(`Successfully migrated: ${file}`);
         }
         if (version > fileNames.length) {
@@ -73,10 +74,8 @@ export class Migrator implements IMigrator {
         const end = start + (currentVersion - version);
         for (let i = start; i < end; i++) {
           const file = fileNames[i] ?? '';
-          await Promise.all([
-            tx.file(path.join(this.migrationsDir, file)).execute(),
-            tx`DELETE FROM migrations WHERE version = ${fileNames.length - i}`
-          ]);
+          await tx.file(path.join(this.migrationsDir, file)).execute();
+          await tx`DELETE FROM ${this.schema}.migrations WHERE version = ${fileNames.length - i}`;
           opts?.eventHandler(`Successfully migrated: ${file}`);
         }
       }
@@ -102,10 +101,8 @@ export class Migrator implements IMigrator {
         for (const fileName of fileNames) {
           const id = fileNames.indexOf(fileName);
           if (id >= currentVersion) {
-            await Promise.all([
-              tx.file(path.join(this.migrationsDir, fileName)).execute(),
-              tx`INSERT INTO migrations(name, version) VALUES (${fileName}, ${id} + 1)`
-            ]);
+            await  tx.file(path.join(this.migrationsDir, fileName)).execute();
+            await  tx`INSERT INTO ${this.schema}.migrations(name, version) VALUES (${fileName}, ${id} + 1)`;
             opts?.eventHandler(`Successfully migrated: ${fileName}`);
           }
         }
@@ -114,10 +111,8 @@ export class Migrator implements IMigrator {
         const start = fileNames.length - currentVersion;
         for (let i = start; i < fileNames.length; i++) {
           const file = fileNames[i] ?? '';
-          await Promise.all([
-            tx.file(path.join(this.migrationsDir, file)).execute(),
-            tx`DELETE FROM migrations WHERE version = ${fileNames.length - i}`
-          ]);
+          await  tx.file(path.join(this.migrationsDir, file)).execute();
+          await  tx`DELETE FROM ${this.schema}.migrations WHERE version = ${fileNames.length - i}`;
           opts?.eventHandler(`Successfully migrated: ${file}`);
         }
       }
@@ -132,12 +127,12 @@ export class Migrator implements IMigrator {
   }
 
   async getCurrentVersion(): Promise<number> {
-    const result = await this.dbClient`SELECT version FROM migrations ORDER BY version DESC LIMIT 1`;
+    const result = await this.dbClient`SELECT version FROM ${this.schema}.migrations ORDER BY version DESC LIMIT 1`;
     return result.length > 0 ? (result[0]?.['version'] as number) : 0;
   }
 
   async getCurrentVersionWithTx(tx: ReservedSql): Promise<number> {
-    const result = await tx`SELECT version FROM migrations ORDER BY version DESC LIMIT 1`;
+    const result = await tx`SELECT version FROM ${this.schema}.migrations ORDER BY version DESC LIMIT 1`;
     return result.length > 0 ? (result[0]?.['version'] as number) : 0;
   }
 

--- a/test/path.test.ts
+++ b/test/path.test.ts
@@ -1,0 +1,203 @@
+import postgres, { type Sql } from 'postgres';
+
+import { Migrator } from '../src/index.js';
+
+describe('Test Postgres.js client', () => {
+  let dbCLient: Sql;
+
+  beforeAll(() => {
+    dbCLient = postgres({
+      host: '127.0.0.1',
+      port: 5432,
+      database: 'pgroll',
+      user: 'pgrolluser',
+      password: 'pgrollpassword',
+      onnotice: () => {
+        // do nothing
+      }
+    });
+  });
+
+  afterAll(async () => {
+    await dbCLient.end();
+  });
+
+  test('uses public schema by default', async () => {
+    const migrator = new Migrator(dbCLient, `${process.cwd()}/test/migrations/`);
+
+    await migrator.up();
+    expect(
+      await dbCLient`
+    SELECT COUNT(*)
+    FROM public.migrations
+  `
+    ).toEqual([{ count: '5' }]);
+    await migrator.down();
+    await dbCLient`DROP TABLE IF EXISTS public.migrations`;
+  });
+
+  test('uses configured schema', async () => {
+    const migrator = new Migrator(dbCLient, `${process.cwd()}/test/migrations/`, 'abc');
+
+    await migrator.up();
+
+    expect(
+      await dbCLient`
+    SELECT COUNT(*)
+    FROM abc.migrations
+  `
+    ).toEqual([{ count: '5' }]);
+
+    expect(
+      await dbCLient`
+    SELECT EXISTS (
+      SELECT 1
+      FROM information_schema.tables
+      WHERE table_schema = 'public'
+      AND table_name = 'migrations'
+    );
+  `
+    ).toEqual([{ exists: false }]);
+
+    await migrator.down();
+
+    await dbCLient`DROP SCHEMA IF EXISTS abc CASCADE`;
+  });
+
+  test('set search path with default schema', async () => {
+    const migrator = new Migrator(dbCLient, `${process.cwd()}/test/migrations/`);
+
+    await dbCLient`SET search_path TO user_path`;
+    await dbCLient`CREATE SCHEMA IF NOT EXISTS user_path`;
+
+    await migrator.up();
+
+    // check if migrations table has all 5 versions
+    expect(
+      await dbCLient`
+      SELECT COUNT(*)
+      FROM public.migrations
+    `
+    ).toEqual([{ count: '5' }]);
+
+    // there should be no migrations table in user's path
+    expect(
+      await dbCLient`
+      SELECT EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = 'user_path'
+        AND table_name = 'migrations'
+      );
+    `
+    ).toEqual([{ exists: false }]);
+
+    // check if user's tables is in the right schema
+    expect(
+      await dbCLient`
+    SELECT COUNT(*)::int AS table_count
+    FROM information_schema.tables
+    WHERE table_schema = 'user_path'
+  `
+    ).toEqual([{ table_count: 4 }]);
+
+    expect(
+      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+                           WHERE  table_schema = 'user_path'   
+                           AND    table_name   = 'users');`
+    ).toEqual([{ exists: true }]);
+    expect(
+      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+                           WHERE  table_schema = 'user_path'   
+                           AND    table_name   = 'games');`
+    ).toEqual([{ exists: true }]);
+    expect(
+      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+                           WHERE  table_schema = 'user_path'   
+                           AND    table_name   = 'news');`
+    ).toEqual([{ exists: true }]);
+    expect(
+      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+                           WHERE  table_schema = 'user_path'  
+                           AND    table_name   = 'classes');`
+    ).toEqual([{ exists: true }]);
+
+    await migrator.down();
+    await dbCLient`DROP SCHEMA IF EXISTS public CASCADE`;
+    await dbCLient`DROP SCHEMA IF EXISTS user_path CASCADE`;
+  });
+
+  test('set search path with specified schema', async () => {
+    const migrator = new Migrator(dbCLient, `${process.cwd()}/test/migrations/`, 'test');
+
+    await dbCLient`SET search_path TO path`;
+    await dbCLient`CREATE SCHEMA IF NOT EXISTS path`;
+
+    await migrator.up();
+
+    // check if migrations table has all 5 versions
+    expect(
+      await dbCLient`
+      SELECT COUNT(*)
+      FROM test.migrations
+    `
+    ).toEqual([{ count: '5' }]);
+
+    // there should be no migrations table in public schema
+    expect(
+      await dbCLient`
+      SELECT EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = 'public'
+        AND table_name = 'migrations'
+      );
+    `
+    ).toEqual([{ exists: false }]);
+
+    // there should be no migrations table in user's path
+    expect(
+      await dbCLient`
+      SELECT EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = 'path'
+        AND table_name = 'migrations'
+      );
+    `
+    ).toEqual([{ exists: false }]);
+
+    // check if user's tables is in the right schema
+    expect(
+      await dbCLient`
+    SELECT COUNT(*)::int AS table_count
+    FROM information_schema.tables
+    WHERE table_schema = 'path'
+  `
+    ).toEqual([{ table_count: 4 }]);
+
+    expect(
+      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+                           WHERE  table_schema = 'path'   
+                           AND    table_name   = 'users');`
+    ).toEqual([{ exists: true }]);
+    expect(
+      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+                           WHERE  table_schema = 'path'   
+                           AND    table_name   = 'games');`
+    ).toEqual([{ exists: true }]);
+    expect(
+      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+                           WHERE  table_schema = 'path'   
+                           AND    table_name   = 'news');`
+    ).toEqual([{ exists: true }]);
+    expect(
+      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+                           WHERE  table_schema = 'path'  
+                           AND    table_name   = 'classes');`
+    ).toEqual([{ exists: true }]);
+
+    await migrator.down();
+    await dbCLient`DROP SCHEMA IF EXISTS path CASCADE`;
+  });
+});

--- a/test/path.test.ts
+++ b/test/path.test.ts
@@ -3,15 +3,19 @@ import postgres, { type Sql } from 'postgres';
 import { Migrator } from '../src/index.js';
 
 describe('Test Postgres.js client', () => {
-  let dbCLient: Sql;
+  let dbClient: Sql;
 
   beforeAll(() => {
-    dbCLient = postgres({
+    dbClient = postgres({
       host: '127.0.0.1',
       port: 5432,
       database: 'pgroll',
       user: 'pgrolluser',
       password: 'pgrollpassword',
+      // Pin the pool to a single connection so `SET search_path` and the
+      // Migrator's reserved connection share the same session — otherwise the
+      // search_path tests would depend on incidental connection reuse.
+      max: 1,
       onnotice: () => {
         // do nothing
       }
@@ -19,185 +23,181 @@ describe('Test Postgres.js client', () => {
   });
 
   afterAll(async () => {
-    await dbCLient.end();
+    await dbClient.end();
+  });
+
+  beforeEach(async () => {
+    // Reset to a clean slate so every test is isolated regardless of order or
+    // what a previous test/file left behind: drop all user schemas (everything
+    // except the Postgres system schemas), recreate an empty `public`, and
+    // restore the default search_path (the search_path tests mutate it).
+    const schemas = await dbClient`
+      SELECT nspname FROM pg_namespace
+      WHERE nspname <> 'information_schema' AND left(nspname, 3) <> 'pg_'`;
+    for (const { nspname } of schemas) {
+      await dbClient`DROP SCHEMA IF EXISTS ${dbClient(nspname)} CASCADE`;
+    }
+    await dbClient`CREATE SCHEMA public`;
+    await dbClient`SET search_path TO public`;
   });
 
   test('uses public schema by default', async () => {
-    const migrator = new Migrator(dbCLient, `${process.cwd()}/test/migrations/`);
-
+    const migrator = new Migrator(dbClient, `${process.cwd()}/test/migrations/`);
     await migrator.up();
+    expect(await dbClient`SELECT COUNT(*)::INT FROM public.migrations`).toEqual([{ count: 5 }]);
     expect(
-      await dbCLient`
-    SELECT COUNT(*)
-    FROM public.migrations
-  `
-    ).toEqual([{ count: '5' }]);
+      await dbClient`SELECT COUNT(*)::INT FROM information_schema.tables
+           WHERE table_schema = 'public'
+           AND (
+             table_name = 'users'
+             OR table_name = 'games'
+             OR table_name = 'news'
+             OR table_name = 'classes')`
+    ).toEqual([{ count: 4 }]);
     await migrator.down();
-    await dbCLient`DROP TABLE IF EXISTS public.migrations`;
+    expect(await dbClient`SELECT COUNT(*)::INT FROM public.migrations`).toEqual([{ count: 0 }]);
+    expect(
+      await dbClient`SELECT COUNT(*)::INT FROM information_schema.tables
+           WHERE table_schema = 'public'
+           AND (
+             table_name = 'users'
+             OR table_name = 'games'
+             OR table_name = 'news'
+             OR table_name = 'classes')`
+    ).toEqual([{ count: 0 }]);
   });
 
   test('uses configured schema', async () => {
-    const migrator = new Migrator(dbCLient, `${process.cwd()}/test/migrations/`, 'abc');
-
+    const migrator = new Migrator(dbClient, `${process.cwd()}/test/migrations/`, 'test');
     await migrator.up();
-
+    expect(await dbClient`SELECT COUNT(*)::INT FROM test.migrations`).toEqual([{ count: 5 }]);
     expect(
-      await dbCLient`
-    SELECT COUNT(*)
-    FROM abc.migrations
-  `
-    ).toEqual([{ count: '5' }]);
-
+      await dbClient`SELECT COUNT(*)::INT FROM information_schema.tables
+        WHERE table_schema = 'public'
+        AND table_name = 'migrations'`
+    ).toEqual([{ count: 0 }]);
     expect(
-      await dbCLient`
-    SELECT EXISTS (
-      SELECT 1
-      FROM information_schema.tables
-      WHERE table_schema = 'public'
-      AND table_name = 'migrations'
-    );
-  `
-    ).toEqual([{ exists: false }]);
-
+      await dbClient`SELECT COUNT(*)::INT FROM information_schema.tables
+           WHERE table_schema = 'public'
+           AND (
+             table_name = 'users'
+             OR table_name = 'games'
+             OR table_name = 'news'
+             OR table_name = 'classes')`
+    ).toEqual([{ count: 4 }]);
     await migrator.down();
-
-    await dbCLient`DROP SCHEMA IF EXISTS abc CASCADE`;
+    expect(await dbClient`SELECT COUNT(*)::INT FROM test.migrations`).toEqual([{ count: 0 }]);
+    expect(
+      await dbClient`SELECT COUNT(*)::INT FROM information_schema.tables
+        WHERE table_schema = 'public'
+        AND table_name = 'migrations'`
+    ).toEqual([{ count: 0 }]);
+    expect(
+      await dbClient`SELECT COUNT(*)::INT FROM information_schema.tables
+           WHERE table_schema = 'public'
+           AND (
+             table_name = 'users'
+             OR table_name = 'games'
+             OR table_name = 'news'
+             OR table_name = 'classes')`
+    ).toEqual([{ count: 0 }]);
   });
 
   test('set search path with default schema', async () => {
-    const migrator = new Migrator(dbCLient, `${process.cwd()}/test/migrations/`);
+    const migrator = new Migrator(dbClient, `${process.cwd()}/test/migrations/`);
 
-    await dbCLient`SET search_path TO user_path`;
-    await dbCLient`CREATE SCHEMA IF NOT EXISTS user_path`;
+    await dbClient`SET search_path TO test`;
+    await dbClient`CREATE SCHEMA test`;
 
     await migrator.up();
-
-    // check if migrations table has all 5 versions
+    expect(await dbClient`SELECT COUNT(*)::INT FROM public.migrations`).toEqual([{ count: 5 }]);
     expect(
-      await dbCLient`
-      SELECT COUNT(*)
-      FROM public.migrations
-    `
-    ).toEqual([{ count: '5' }]);
-
-    // there should be no migrations table in user's path
-    expect(
-      await dbCLient`
-      SELECT EXISTS (
-        SELECT 1
+      await dbClient`SELECT COUNT(*)::INT
         FROM information_schema.tables
-        WHERE table_schema = 'user_path'
-        AND table_name = 'migrations'
-      );
-    `
-    ).toEqual([{ exists: false }]);
-
-    // check if user's tables is in the right schema
+        WHERE table_schema = 'test' AND table_name = 'migrations';`
+    ).toEqual([{ count: 0 }]);
     expect(
-      await dbCLient`
-    SELECT COUNT(*)::int AS table_count
-    FROM information_schema.tables
-    WHERE table_schema = 'user_path'
-  `
-    ).toEqual([{ table_count: 4 }]);
-
-    expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
-                           WHERE  table_schema = 'user_path'   
-                           AND    table_name   = 'users');`
-    ).toEqual([{ exists: true }]);
-    expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
-                           WHERE  table_schema = 'user_path'   
-                           AND    table_name   = 'games');`
-    ).toEqual([{ exists: true }]);
-    expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
-                           WHERE  table_schema = 'user_path'   
-                           AND    table_name   = 'news');`
-    ).toEqual([{ exists: true }]);
-    expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
-                           WHERE  table_schema = 'user_path'  
-                           AND    table_name   = 'classes');`
-    ).toEqual([{ exists: true }]);
+      await dbClient`SELECT COUNT(*)::INT FROM information_schema.tables
+           WHERE table_schema = 'test'
+           AND (
+             table_name = 'users'
+             OR table_name = 'games'
+             OR table_name = 'news'
+             OR table_name = 'classes')`
+    ).toEqual([{ count: 4 }]);
 
     await migrator.down();
-    await dbCLient`DROP SCHEMA IF EXISTS public CASCADE`;
-    await dbCLient`DROP SCHEMA IF EXISTS user_path CASCADE`;
+    expect(await dbClient`SELECT COUNT(*)::INT FROM public.migrations`).toEqual([{ count: 0 }]);
+    expect(
+      await dbClient`SELECT COUNT(*)::INT
+        FROM information_schema.tables
+        WHERE table_schema = 'test' AND table_name = 'migrations';`
+    ).toEqual([{ count: 0 }]);
+    expect(
+      await dbClient`SELECT COUNT(*)::INT FROM information_schema.tables
+           WHERE table_schema = 'test'
+           AND (
+             table_name = 'users'
+             OR table_name = 'games'
+             OR table_name = 'news'
+             OR table_name = 'classes')`
+    ).toEqual([{ count: 0 }]);
   });
 
   test('set search path with specified schema', async () => {
-    const migrator = new Migrator(dbCLient, `${process.cwd()}/test/migrations/`, 'test');
+    const migrator = new Migrator(dbClient, `${process.cwd()}/test/migrations/`, 'test');
 
-    await dbCLient`SET search_path TO path`;
-    await dbCLient`CREATE SCHEMA IF NOT EXISTS path`;
+    await dbClient`SET search_path TO my_path`;
+    await dbClient`CREATE SCHEMA my_path`;
 
     await migrator.up();
-
-    // check if migrations table has all 5 versions
+    expect(await dbClient`SELECT COUNT(*)::INT FROM test.migrations`).toEqual([{ count: 5 }]);
     expect(
-      await dbCLient`
-      SELECT COUNT(*)
-      FROM test.migrations
-    `
-    ).toEqual([{ count: '5' }]);
-
-    // there should be no migrations table in public schema
-    expect(
-      await dbCLient`
-      SELECT EXISTS (
-        SELECT 1
+      await dbClient`SELECT COUNT(*)::INT
         FROM information_schema.tables
         WHERE table_schema = 'public'
-        AND table_name = 'migrations'
-      );
-    `
-    ).toEqual([{ exists: false }]);
-
-    // there should be no migrations table in user's path
+        AND table_name = 'migrations'`
+    ).toEqual([{ count: 0 }]);
     expect(
-      await dbCLient`
-      SELECT EXISTS (
-        SELECT 1
+      await dbClient`SELECT COUNT(*)::INT
         FROM information_schema.tables
-        WHERE table_schema = 'path'
-        AND table_name = 'migrations'
-      );
-    `
-    ).toEqual([{ exists: false }]);
-
-    // check if user's tables is in the right schema
+        WHERE table_schema = 'my_path'
+        AND table_name = 'migrations'`
+    ).toEqual([{ count: 0 }]);
     expect(
-      await dbCLient`
-    SELECT COUNT(*)::int AS table_count
-    FROM information_schema.tables
-    WHERE table_schema = 'path'
-  `
-    ).toEqual([{ table_count: 4 }]);
-
-    expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
-                           WHERE  table_schema = 'path'   
-                           AND    table_name   = 'users');`
-    ).toEqual([{ exists: true }]);
-    expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
-                           WHERE  table_schema = 'path'   
-                           AND    table_name   = 'games');`
-    ).toEqual([{ exists: true }]);
-    expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
-                           WHERE  table_schema = 'path'   
-                           AND    table_name   = 'news');`
-    ).toEqual([{ exists: true }]);
-    expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
-                           WHERE  table_schema = 'path'  
-                           AND    table_name   = 'classes');`
-    ).toEqual([{ exists: true }]);
+      await dbClient`SELECT COUNT(*)::INT
+      FROM information_schema.tables
+      WHERE table_schema = 'my_path'
+      AND (
+        table_name = 'users'
+        OR table_name = 'games'
+        OR table_name = 'news'
+        OR table_name = 'classes')`
+    ).toEqual([{ count: 4 }]);
 
     await migrator.down();
-    await dbCLient`DROP SCHEMA IF EXISTS path CASCADE`;
+    expect(await dbClient`SELECT COUNT(*)::INT FROM test.migrations`).toEqual([{ count: 0 }]);
+    expect(
+      await dbClient`SELECT COUNT(*)::INT
+        FROM information_schema.tables
+        WHERE table_schema = 'public'
+        AND table_name = 'migrations'`
+    ).toEqual([{ count: 0 }]);
+    expect(
+      await dbClient`SELECT COUNT(*)::INT
+        FROM information_schema.tables
+        WHERE table_schema = 'my_path'
+        AND table_name = 'migrations'`
+    ).toEqual([{ count: 0 }]);
+    expect(
+      await dbClient`SELECT COUNT(*)::INT
+      FROM information_schema.tables
+      WHERE table_schema = 'my_path'
+      AND (
+        table_name = 'users'
+        OR table_name = 'games'
+        OR table_name = 'news'
+        OR table_name = 'classes')`
+    ).toEqual([{ count: 0 }]);
   });
 });

--- a/test/pjs.test.ts
+++ b/test/pjs.test.ts
@@ -3,11 +3,11 @@ import postgres, { type Sql } from 'postgres';
 import { type IMigrator, Migrator } from '../src/index.js';
 
 describe('Test Postgres.js client', () => {
-  let dbCLient: Sql;
+  let dbClient: Sql;
   let migrator: IMigrator;
 
   beforeAll(() => {
-    dbCLient = postgres({
+    dbClient = postgres({
       host: '127.0.0.1',
       port: 5432,
       database: 'pgroll',
@@ -17,33 +17,33 @@ describe('Test Postgres.js client', () => {
         // do nothing
       }
     });
-    migrator = new Migrator(dbCLient, `${process.cwd()}/test/migrations/`);
+    migrator = new Migrator(dbClient, `${process.cwd()}/test/migrations/`);
   });
 
   afterAll(async () => {
-    await dbCLient.end();
+    await dbClient.end();
   });
 
   test('up success', async () => {
     await migrator.up();
     expect(await migrator.getCurrentVersion()).toBe(5);
     expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+      await dbClient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
                            WHERE  table_schema = 'public'   -- Replace with your schema name if different
                            AND    table_name   = 'users');`
     ).toEqual([{ exists: true }]);
     expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+      await dbClient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
                            WHERE  table_schema = 'public'   -- Replace with your schema name if different
                            AND    table_name   = 'games');`
     ).toEqual([{ exists: true }]);
     expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+      await dbClient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
                            WHERE  table_schema = 'public'   -- Replace with your schema name if different
                            AND    table_name   = 'news');`
     ).toEqual([{ exists: true }]);
     expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+      await dbClient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
                            WHERE  table_schema = 'public'   -- Replace with your schema name if different
                            AND    table_name   = 'classes');`
     ).toEqual([{ exists: true }]);
@@ -56,22 +56,22 @@ describe('Test Postgres.js client', () => {
     await migrator.down();
     expect(await migrator.getCurrentVersion()).toBe(0);
     expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+      await dbClient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
                            WHERE  table_schema = 'public'   -- Replace with your schema name if different
                            AND    table_name   = 'users');`
     ).toEqual([{ exists: false }]);
     expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+      await dbClient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
                            WHERE  table_schema = 'public'   -- Replace with your schema name if different
                            AND    table_name   = 'games');`
     ).toEqual([{ exists: false }]);
     expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+      await dbClient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
                            WHERE  table_schema = 'public'   -- Replace with your schema name if different
                            AND    table_name   = 'news');`
     ).toEqual([{ exists: false }]);
     expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+      await dbClient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
                            WHERE  table_schema = 'public'   -- Replace with your schema name if different
                            AND    table_name   = 'classes');`
     ).toEqual([{ exists: false }]);
@@ -102,12 +102,12 @@ describe('Test Postgres.js client', () => {
     await migrator.go(2);
     expect(await migrator.getCurrentVersion()).toBe(2);
     expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+      await dbClient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
                            WHERE  table_schema = 'public'   -- Replace with your schema name if different
                            AND    table_name   = 'users');`
     ).toEqual([{ exists: true }]);
     expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+      await dbClient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
                            WHERE  table_schema = 'public'   -- Replace with your schema name if different
                            AND    table_name   = 'games');`
     ).toEqual([{ exists: true }]);
@@ -116,36 +116,36 @@ describe('Test Postgres.js client', () => {
     await migrator.go(7);
     expect(await migrator.getCurrentVersion()).toBe(5);
     expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+      await dbClient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
                            WHERE  table_schema = 'public'   -- Replace with your schema name if different
                            AND    table_name   = 'news');`
     ).toEqual([{ exists: true }]);
     expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+      await dbClient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
                            WHERE  table_schema = 'public'   -- Replace with your schema name if different
                            AND    table_name   = 'classes');`
     ).toEqual([{ exists: true }]);
     await migrator.go(2);
     expect(await migrator.getCurrentVersion()).toBe(2);
     expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+      await dbClient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
                            WHERE  table_schema = 'public'   -- Replace with your schema name if different
                            AND    table_name   = 'news');`
     ).toEqual([{ exists: false }]);
     expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+      await dbClient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
                            WHERE  table_schema = 'public'   -- Replace with your schema name if different
                            AND    table_name   = 'classes');`
     ).toEqual([{ exists: false }]);
     await migrator.go(0);
     expect(await migrator.getCurrentVersion()).toBe(0);
     expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+      await dbClient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
                            WHERE  table_schema = 'public'   -- Replace with your schema name if different
                            AND    table_name   = 'users');`
     ).toEqual([{ exists: false }]);
     expect(
-      await dbCLient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+      await dbClient`SELECT EXISTS (SELECT 1 FROM information_schema.tables
                            WHERE  table_schema = 'public'   -- Replace with your schema name if different
                            AND    table_name   = 'games');`
     ).toEqual([{ exists: false }]);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    fileParallelism: false,
     include: ['test/**/*.test.ts'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION


### Changes

* Schema-qualified all references to the internal `migrations` table to prevent them from being affected by changes to the session `search_path`.
* Added a configurable schema option (default: `public`) for the migration metadata table.
* Added a `-s` / `--schema` CLI flag to allow specifying the schema used for pgroll's internal migration table.
* Updated migration bookkeeping to execute sequentially after the migration succeeds, ensuring the migration state accurately reflects the database state.



Fixes #2 